### PR TITLE
[FIX] 레이아웃 overflow 관련 이슈

### DIFF
--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -9,7 +9,7 @@ const Layout = () => {
   const { title, backNav } = LINK_TITLE[pathname + search]
 
   return (
-    <div className="bg-[url('/src/assets/bg.png')] w-screen h-screen bg-cover">
+    <div className="bg-[url('/src/assets/bg.png')] w-screen h-screen bg-cover overflow-hidden">
       {/* 임시: ticketCount는 임의의 숫자 */}
       <TopBar title={title} backNav={backNav as string} ticketCount={1}></TopBar>
       <Spacing direction="vertical" size={44}></Spacing>


### PR DESCRIPTION
## 🔍 관련 자료
* 이슈 넘버: #15 

## 📝 변경 내용
터치해서 드래그 하지 못하도록 Layout 컴포넌트의 가장 상위 div에 `overflow-hidden`을 추가해주었습니다.

## 📸 결과
![Kapture 2023-09-13 at 02 52 15](https://github.com/yourssu/autumn-ssu-dating/assets/78731710/7d956675-16b2-4c30-bb8a-90588b260be3)


