### PR TITLE
Feat/#25 Checkbox 컴포넌트 생성

### DIFF
--- a/src/components/common/Checkbox.tsx
+++ b/src/components/common/Checkbox.tsx
@@ -1,0 +1,31 @@
+import checkedIcon from '../../assets/checkedIcon.svg'
+import uncheckedIcon from '../../assets/uncheckedIcon.svg'
+
+interface CheckboxProps {
+  checkCase: '등록' | '연락처 확인'
+  isChecked: boolean
+  onImgClick: React.MouseEventHandler<HTMLImageElement>
+  onLabelClick: React.ChangeEventHandler<HTMLInputElement>
+}
+
+const Checkbox = ({
+  checkCase = '연락처 확인',
+  isChecked,
+  onImgClick,
+  onLabelClick,
+}: CheckboxProps) => {
+  return (
+    <div className="flex justify-center">
+      <img
+        src={isChecked ? (checkedIcon as string) : (uncheckedIcon as string)}
+        onClick={onImgClick}
+      />
+      <label className="text-caption text-pink ml-1 my-2">
+        <input type="checkbox" onChange={onLabelClick} className="hidden" />
+        {checkCase} 시 이용권 한 장이 차감됩니다. (남은 이용권수: n장)
+      </label>
+    </div>
+  )
+}
+
+export default Checkbox


### PR DESCRIPTION
## 🔍 관련 자료
* 이슈 넘버: #25 

## 📝 변경 내용
* `PersonalInfoStep`에 존재하던 체크박스를 공통 컴포넌트로 분리했습니다

실제 사용할 때 코드는 아래와 같습니다
![image](https://github.com/yourssu/autumn-ssu-dating/assets/87255462/78b95994-6cb4-4301-895d-6c8ad808005c)


## 📸 결과
|피그마 화면|실제 구현|
|---|---|
|![268010943-30098e1b-b9d6-47a0-b462-1b0df2a0b571](https://github.com/yourssu/autumn-ssu-dating/assets/87255462/76538cb2-4723-4bcc-b897-e7f002cfc424)|![test](https://github.com/yourssu/autumn-ssu-dating/assets/87255462/00ca5838-5f8e-4532-810a-4f5118e6404a)|

