### PR TITLE
Fix/#18 InputField 입력값 없을 때 그림자가 없는 현상

### DIFF
--- a/src/components/common/InputField.tsx
+++ b/src/components/common/InputField.tsx
@@ -9,6 +9,10 @@ const InputField = ({ width = 193, height = 48, ...props }: InputFieldProps) => 
   // 임의 -> 추후에 수정될 수도 있음
   const [inputValue, setInputValue] = useState('')
 
+  const defaultStyle =
+    'px-4 bg-white rounded-xl flex justify-start items-center focus:outline-none text-pink placeholder-gray font-body2 focus:shadow-inputField'
+  const shadowStyle = !props.value && 'shadow-inputField'
+
   return (
     <input
       type="text"
@@ -17,7 +21,7 @@ const InputField = ({ width = 193, height = 48, ...props }: InputFieldProps) => 
         setInputValue(e.target.value)
       }}
       style={{ width: `${width}px`, height: `${height}px` }}
-      className={`px-4 bg-white rounded-xl flex justify-start items-center focus:outline-none text-pink placeholder-gray font-body2 focus:shadow-inputField`}
+      className={`${defaultStyle} ${shadowStyle}`}
       {...props}
     ></input>
   )


### PR DESCRIPTION
## 🔍 관련 자료
* 이슈 넘버: #18 

## 📝 변경 내용
* `shadowStyle` 변수를 추가해서 `value` 값이 빈 문자열일 때 그림자를 추가했습니다!!

## 📸 결과
|피그마 화면|실제 구현|
|---|---|
|![image](https://github.com/yourssu/autumn-ssu-dating/assets/87255462/1eaccc25-7259-4613-868f-73bf2a8d652a)|![test](https://github.com/yourssu/autumn-ssu-dating/assets/87255462/59c28521-05b2-4b69-8baf-5507c96c718f)|

## 🎻
브랜치 타입 feat가 아니라 fix네요......... 근데 이제 pr 다 올리고 깨달은..... 멋쓱