### PR TITLE
Fix/#29 SizeType 타입에 extraSmall 추가

### DIFF
--- a/src/types/boxButton.type.ts
+++ b/src/types/boxButton.type.ts
@@ -1,3 +1,3 @@
 export type IsDisabledType = 'disabled' | 'abled'
 export type IsLineType = 'line' | 'filled'
-export type SizeType = 'small' | 'large'
+export type SizeType = 'small' | 'large' | 'extraSmall'


### PR DESCRIPTION
## 🔍 관련 자료
* 이슈 넘버: #29 

## 📝 변경 내용
* `BoxButton` - `sizeStyle`에만 extraSmall을 추가할 게 아니라, SizeType에도 추가했어야 했는데 ^^....... 저는 바보네요