### PR TITLE
Feat/#2 프로필 등록하기 페이지 토스트, 뒤로가기 이벤트 처리

### DIFF
--- a/src/components/Register/index.tsx
+++ b/src/components/Register/index.tsx
@@ -112,8 +112,21 @@ const Register = () => {
     }
   }
 
+  function handlePopState() {
+    const currentURL = window.location.href
+
+    if (currentURL.includes('step=')) {
+      navigate('/')
+    }
+  }
+
   useEffect(() => {
     updateStep(0)
+    window.addEventListener('popstate', handlePopState)
+
+    return () => {
+      window.removeEventListener('popstate', handlePopState)
+    }
   }, [])
 
   return (


### PR DESCRIPTION
## 🔍 관련 자료
* 이슈 넘버: #2 

## 📝 변경 내용
* 실패 토스트 띄우는 방식을 수정했습니다. 노출 여부를 나타내는 `showToast`를 삭제하고 `failToast`로만 제어합니다.

* `TopBar`의 뒤로가기 버튼이 아닌, 브라우저 버튼 or 마우스 뒤로가기 버튼을 통한 이벤트 발생 시 처리 로직을 추가했습니다

## 📸 결과
#### 테스트 할 때 주의할 점
사진처럼 모바일 기기를 켰을 때는 브라우저의 뒤로가기를 직접 눌러야 확인 가능합니다. 모바일 기기에서 마우스의 뒤로가기 버튼은 작동하지 않습니다 (원래 그런 거 같아요!! 다른 곳에서도 안되는 거 보니까)
![image](https://github.com/yourssu/autumn-ssu-dating/assets/87255462/430abdc9-26c6-4a60-889c-ec428a1ae170)

|수정 전|수정 후|
|---|---|
|![tets](https://github.com/yourssu/autumn-ssu-dating/assets/87255462/78b6aa88-7365-43a0-9d89-483f4ed324f3)|![correct](https://github.com/yourssu/autumn-ssu-dating/assets/87255462/1c17b3f6-7361-49ac-8661-8770a2676ad9)|
|뒤로가기 여러번 눌러야 작동함|뒤로가기 한번 누르면 홈으로 잘 감|
