### PR TITLE
Feat/#28 시작 화면 동물 카드 자동 스크롤 이벤트 추가

### DIFF
--- a/src/components/Home/index.tsx
+++ b/src/components/Home/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 
 import { AxiosError } from 'axios'
 import { useNavigate } from 'react-router-dom'
@@ -24,6 +24,7 @@ const Home = () => {
   const [toastMessage, setToastMessage] = useState<string>('')
 
   const animalOptions = getAnimalOptions()
+  const animalCardRef = useRef<HTMLDivElement>(null)
 
   const navigate = useNavigate()
 
@@ -75,6 +76,26 @@ const Home = () => {
     }
   }, [])
 
+  useEffect(() => {
+    let scrollInterval = 1
+    const scrollBox = animalCardRef.current as HTMLDivElement
+    const scrollWidth = scrollBox.scrollWidth
+    const clientWidth = scrollBox.clientWidth
+
+    const timer = setInterval(() => {
+      const scrollLeft = scrollBox.scrollLeft
+      animalCardRef.current?.scrollTo(scrollLeft + scrollInterval, 0)
+
+      if (scrollBox.scrollLeft === 0 || scrollBox.scrollLeft + clientWidth == scrollWidth) {
+        scrollInterval *= -1
+      }
+    }, 20)
+
+    return () => {
+      clearInterval(timer)
+    }
+  }, [])
+
   return (
     <div>
       <p className="w-[342px] text-center text-pink text-titleBold whitespace-pre-line">
@@ -109,7 +130,10 @@ const Home = () => {
         </p>
       </div>
       <Spacing direction="vertical" size={40} />
-      <div className="grid grid-flow-col gap-x-5 overflow-scroll w-[343px] scrollbar-hide">
+      <div
+        className="grid grid-flow-col gap-x-5 overflow-scroll w-[343px] scrollbar-hide"
+        ref={animalCardRef}
+      >
         {animalOptions.map((option, index) => (
           <TypeButton key={index}>
             <img src={option.src} />


### PR DESCRIPTION
## 🔍 관련 자료
* 이슈 넘버: #28 

## 📝 변경 내용
* Home에서 동물 카드가 들어있는 Div가 자동으로 스크롤 되는 이벤트를 추가했습니다

## 📸 결과
용량 문제로 스크롤 애니메이션 전체를 녹화하지는 않았지만, 스크롤이 양 끝에 닿으면 반대 방향으로 스크롤 하게 해뒀습니다

|피그마 화면|실제 구현|
|---|---|
|![image](https://github.com/yourssu/autumn-ssu-dating/assets/87255462/0999cc71-49d3-41c6-b6c5-b6906dbe39f5)|![tets](https://github.com/yourssu/autumn-ssu-dating/assets/87255462/2a981fb8-5f8d-4998-9a9c-9187c52a2d14)|

