### PR TITLE
Feat/#63 Pretendard 폰트 적용

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,13 +1,18 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
-  </body>
+
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+  <link rel="stylesheet" as="style" crossorigin
+    href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.8/dist/web/variable/pretendardvariable-dynamic-subset.css" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Vite + React + TS</title>
+</head>
+
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+
 </html>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,7 @@
 import type { Config } from 'tailwindcss'
 
+const defaultTheme = require('tailwindcss/defaultTheme')
+
 const config: Config = {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
@@ -57,6 +59,9 @@ const config: Config = {
             lineHeight: '15.6px',
           },
         ],
+      },
+      fontFamily: {
+        sans: ['Pretendard Variable', ...defaultTheme.fontFamily.sans],
       },
     },
     boxShadow: {


### PR DESCRIPTION
## 🔍 관련 자료
* 이슈 넘버: #63
* 레퍼런스: [Pretendard github](https://github.com/orioncactus/pretendard), [tailwindcss font-family](https://tailwindcss.com/docs/font-family)

## 📝 변경 내용
* 폰트를 적용했습니다! 좀.. 헤매서 늦었지만.. 😂

* 가변 다이나믹 서브셋으로 가져왔어용
![image](https://github.com/yourssu/autumn-ssu-dating/assets/87255462/3a1ad9a6-f55f-4515-b9c3-83b3fc9197bd)
 
## 📸 결과
|피그마 화면|실제 구현|
|---|---|
|![image](https://github.com/yourssu/autumn-ssu-dating/assets/87255462/fb116eae-bc73-4dfe-9ffd-736aa9632eb3)|![image](https://github.com/yourssu/autumn-ssu-dating/assets/87255462/1ee6e815-af9a-42d4-98e5-4796b8a563a9)|
