### PR TITLE
Fix/#66 Home에 들어가는 화면 요소 width 수정

### DIFF
--- a/src/components/Home/index.tsx
+++ b/src/components/Home/index.tsx
@@ -98,7 +98,7 @@ const Home = () => {
 
   return (
     <div className="flex flex-col justify-center items-center h-full">
-      <p className="w-[342px] text-center text-pink text-titleBold whitespace-pre-line">
+      <p className="text-center text-pink text-titleBold whitespace-pre-line">
         {'뿌슝이의\n동물 SSU개팅'}
       </p>
       <Spacing direction="vertical" size={15} />
@@ -122,7 +122,7 @@ const Home = () => {
         </BoxButton>
       </div>
       <Spacing direction="vertical" size={12} />
-      <div className="w-[342px] flex justify-center text-body2">
+      <div className="flex justify-center text-body2">
         <img src={ticket as string} className="h-[22px]" alt="티켓 아이콘" />
         <Spacing direction="horizontal" size={4} />
         <p>
@@ -131,7 +131,7 @@ const Home = () => {
       </div>
       <Spacing direction="vertical" size={40} />
       <div
-        className="grid grid-flow-col gap-x-5 overflow-scroll w-[343px] scrollbar-hide"
+        className="grid grid-flow-col gap-x-5 overflow-scroll w-full scrollbar-hide"
         ref={animalCardRef}
       >
         {animalOptions.map((option, index) => (


### PR DESCRIPTION
## 🔍 관련 자료
* 이슈 넘버: #66 

## 📝 변경 내용
* 불필요한 w-[342px] 때문에 동물 카드 좌우로 여백이 생겨서, 지웠습니다
* 이참에 타이틀, 이용권에 적용되어있던 width도 삭제했습니다

## 📸 결과
|피그마 화면|실제 구현|
|---|---|
|![image](https://github.com/yourssu/autumn-ssu-dating/assets/87255462/b7bd5d07-7eab-4c83-853a-a8f40f9b981b)|![tets](https://github.com/yourssu/autumn-ssu-dating/assets/87255462/14532220-75c3-45e2-a1f6-3f38b73f201c)|
