### PR TITLE
Fix: PersonalInfoStep 연락처 문구 수정

### DIFF
--- a/src/components/Register/PersonalInfoStep.tsx
+++ b/src/components/Register/PersonalInfoStep.tsx
@@ -92,7 +92,7 @@ const PersonalInfoStep = ({ nickName, mbti, introduce, contact, updateFields }: 
             />
           </div>
           <div>
-            <label>연락처 (인스타그램 ID / 전화번호)</label>
+            <label>연락처 (인스타그램, 카카오톡 ID or 전화번호)</label>
             <Spacing direction="vertical" size={8} />
             <InputField
               required


### PR DESCRIPTION
## 📝 변경 내용
* `연락처` 옆 괄호 내용을 수정했습니다. 수정 이유는 아래와 같습니다
![image](https://github.com/yourssu/autumn-ssu-dating/assets/87255462/e1b2895c-3f09-4216-83fb-27e0e71d6fcd)


## 📸 결과
|피그마 화면|실제 구현|
|---|---|
||![image](https://github.com/yourssu/autumn-ssu-dating/assets/87255462/f2a92ed0-24e8-4471-8d51-8398d440e66d)|
