### PR TITLE
Refactor(Register): api 요청에 client 사용

### DIFF
--- a/src/apis/registerApi.ts
+++ b/src/apis/registerApi.ts
@@ -11,9 +11,6 @@ export const registerProfile = async ({
   gender: string
   profile: RegisterRequest
 }): Promise<AxiosResponse<RegisterResponse>> => {
-  const response = await client.post(
-    `https://ssudate.xodns.site/register/${gender === '여자' ? 'female' : 'male'}`,
-    profile
-  )
+  const response = await client.post(`/register/${gender === '여자' ? 'female' : 'male'}`, profile)
   return response
 }


### PR DESCRIPTION
## 📝 변경 내용
api 요청에 `client`를 불러와놓긴 했는데.. url은 수정 안하고 그대로 둔 이런 바보감자같은 행동을 수정했습니다