### PR TITLE
Fix/#98 InputField state, onchange 삭제

### DIFF
--- a/src/components/common/InputField.tsx
+++ b/src/components/common/InputField.tsx
@@ -1,14 +1,9 @@
-import { useState } from 'react'
-
 interface InputFieldProps extends React.InputHTMLAttributes<HTMLInputElement> {
   width?: number
   height?: number
 }
 
 const InputField = ({ width = 193, height = 48, ...props }: InputFieldProps) => {
-  // 임의 -> 추후에 수정될 수도 있음
-  const [inputValue, setInputValue] = useState('')
-
   const defaultStyle =
     'px-4 bg-white rounded-xl flex justify-start items-center focus:outline-none text-pink placeholder-gray text-body2 focus:shadow-inputField'
   const shadowStyle = !props.value && 'shadow-inputField'
@@ -16,10 +11,6 @@ const InputField = ({ width = 193, height = 48, ...props }: InputFieldProps) => 
   return (
     <input
       type="text"
-      value={inputValue}
-      onChange={(e) => {
-        setInputValue(e.target.value)
-      }}
       style={{ width: `${width}px`, height: `${height}px` }}
       className={`${defaultStyle} ${shadowStyle}`}
       {...props}


### PR DESCRIPTION
## 🔍 관련 자료
* 이슈 넘버: #98

## 📝 변경 내용
* `InputField` 컴포넌트에 있던 상태 값과 onChange 이벤트를 삭제했습니다

## 📸 결과
![tets](https://github.com/yourssu/autumn-ssu-dating/assets/87255462/c360a3a0-e331-446f-8254-86fabb9b5b83)

