### PR TITLE
Fix/#101 브라우저 번역 기능 대응

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,20 +1,18 @@
 <!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.png" />
-    <link
-      rel="stylesheet"
-      as="style"
-      crossorigin
-      href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.8/dist/web/variable/pretendardvariable-dynamic-subset.css"
-    />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>슈개팅</title>
-  </head>
+<html lang="ko">
 
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
-  </body>
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.png" />
+  <link rel="stylesheet" as="style" crossorigin
+    href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.8/dist/web/variable/pretendardvariable-dynamic-subset.css" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>슈개팅</title>
+</head>
+
+<body class="notranslate">
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+
 </html>


### PR DESCRIPTION
## 🔍 관련 자료
* 이슈 넘버: #101 
* 레퍼런스: [ms 문서 - Translator를 사용하여 콘텐츠가 번역되지 않도록 하는 방법](https://learn.microsoft.com/ko-kr/azure/ai-services/translator/prevent-translation)

## 📝 변경 내용
* index.html을 수정했습니다
  *  `lang="en"` ➡ `lang="ko"` 

  크롬에서 번역 키면 한국어로 번역하려고 하길래 왜 한국어 사이트를 한국어로 번역하지? 했는데 이거 때문인 거 같아요

  * body 태그에 `class="notranslate"` 추가 (레퍼런스 참고)
  ![image](https://github.com/yourssu/autumn-ssu-dating/assets/87255462/420f625f-9038-4573-af57-6d3247e7afc6)

## 📸 결과
1) 이제 크롬에서는 번역이 아예 안 됩니다 (개 아님 ㅠㅠ1!)
![image](https://github.com/yourssu/autumn-ssu-dating/assets/87255462/f1f7966d-3539-4906-a194-451ca63f2a1f)

2) 엣지에서는 번역이 되지만 tooltip은 정상적인 값으로 잘 뜹니다. 사진은 카자흐어에요 ㅎㅎ..
![image](https://github.com/yourssu/autumn-ssu-dating/assets/87255462/78e154b0-87ba-4427-b400-a6af916ad97c)


