### PR TITLE
Feat/#123 카카오 로그인 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import Explore from './components/Explore'
 import Home from './components/Home'
 import Layout from './components/Layout'
 import NotFound from './components/NotFound'
+import Redirect from './components/Redirect'
 import Register from './components/Register'
 
 const App = () => {
@@ -18,6 +19,7 @@ const App = () => {
             <Route path="/explore" element={<Explore />} />
             <Route path="/register" element={<Register />} />
           </Route>
+          <Route path="/kakaoredirect" element={<Redirect />} />
           <Route path="/*" element={<NotFound />} />
         </Routes>
       </BrowserRouter>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ const App = () => {
             <Route path="/explore" element={<Explore />} />
             <Route path="/register" element={<Register />} />
           </Route>
-          <Route path="/kakaoredirect" element={<Redirect />} />
+          <Route path="/kakao-redirect" element={<Redirect />} />
           <Route path="/*" element={<NotFound />} />
         </Routes>
       </BrowserRouter>

--- a/src/components/Home/index.tsx
+++ b/src/components/Home/index.tsx
@@ -9,6 +9,7 @@ import Policy from './atoms/Policy'
 import { authCode } from '../../apis/authApi'
 import myPageIcon from '../../assets/myPageIcon.svg'
 import ticket from '../../assets/ticket.svg'
+import { LOGIN_LINK } from '../../constant'
 import useRecoilToast from '../../hooks/useRecoilToast'
 import useToast from '../../hooks/useToast'
 import { registerToastAtom } from '../../state/registerToastAtom'
@@ -175,8 +176,6 @@ const AfterLogin = () => {
 }
 
 const BeforeLogin = () => {
-  const navigate = useNavigate()
-
   return (
     <>
       <p className="whitespace-pre-line text-center text-titleBold text-pink">
@@ -187,7 +186,7 @@ const BeforeLogin = () => {
         <button
           className="h-full w-full rounded-[12px]"
           onClick={() => {
-            navigate('/login') // 백엔드에서 제공하는 로그인 링크로 수정
+            window.location.assign(LOGIN_LINK)
           }}
         >
           SSU개팅 진행하기

--- a/src/components/Redirect/index.tsx
+++ b/src/components/Redirect/index.tsx
@@ -7,13 +7,10 @@ const Redirect = () => {
   const navigate = useNavigate()
 
   useEffect(() => {
-    console.log(code)
     if (code) {
       navigate('/register', { state: { code } })
     }
   }, [code])
-
-  return <div>Redirect</div>
 }
 
 export default Redirect

--- a/src/components/Redirect/index.tsx
+++ b/src/components/Redirect/index.tsx
@@ -1,0 +1,19 @@
+import { useEffect } from 'react'
+
+import { useNavigate } from 'react-router-dom'
+
+const Redirect = () => {
+  const code = new URL(document.location.toString()).searchParams.get('oauthName')
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    console.log(code)
+    if (code) {
+      navigate('/register', { state: { code } })
+    }
+  }, [code])
+
+  return <div>Redirect</div>
+}
+
+export default Redirect

--- a/src/components/Register/index.tsx
+++ b/src/components/Register/index.tsx
@@ -28,6 +28,11 @@ const Register = () => {
   const navigate = useNavigate()
   const location = useLocation()
 
+  // 보리가 여기서 정보 빼서 사용하시면 됩니다 :)
+  useEffect(() => {
+    console.log(location.state)
+  }, [location.state])
+
   const [formData, setFormData] = useState<FormData>({
     gender: '',
     animals: 'ALL',

--- a/src/constant/index.ts
+++ b/src/constant/index.ts
@@ -29,3 +29,7 @@ export const ANIMAL_OPTIONS_FEMALE: FormStepOption[] = [
   { src: '/hamsterIcon.png', label: '햄스터', animals: 'HAMSTER' },
   { src: '/ppussungIcon.png', label: '뿌슝이', animals: 'PUSSUNG' },
 ]
+
+// 서버 배포 이후 수정 필요
+export const LOGIN_LINK =
+  'http://ec2-13-125-112-2.ap-northeast-2.compute.amazonaws.com/oauth2/authorization/kakao'


### PR DESCRIPTION
## 🔍 관련 자료
* 이슈 넘버: #123 

## 📝 변경 내용
- Redirect 컴포넌트를 /kakaoredirect에 라우팅 했습니다.
- 해당 컴포넌트 내부에서 oauthName을 params에서 긁어온 후, register에 navigate하면서 데이터를 같이 담아서 보냈습니다!
- 보리가 useLocation 활용해서 정보 받아오시면 될 것 같아요! 이미 사용중이셔서 `location.state.code`로 가져오시면 될듯합니다!! 제가 주석 달아둔 부분은 확인하시고 지워 버리셔도 될 것 같아요

## 📸 결과
눈에는 안 보여요 ㅠ
