### PR TITLE
Refactor/#124 등록하기 페이지 요청에 oauthname 사용

### DIFF
--- a/src/components/Register/atoms/PersonalInfoStep.tsx
+++ b/src/components/Register/atoms/PersonalInfoStep.tsx
@@ -93,6 +93,10 @@ const PersonalInfoStep = ({ nickName, mbti, introduce, contact, updateFields }: 
               value={contact}
               onChange={(e) => updateFields({ contact: (e.target as HTMLInputElement).value })}
             />
+            <Spacing direction="vertical" size={8} />
+            <p className="text-caption text-gray">
+              * 연락처의 경우 프로필을 가져간 사람에게만 공개됩니다.
+            </p>
           </div>
         </div>
         <Spacing direction="vertical" size={8} />

--- a/src/components/Register/atoms/PersonalInfoStep.tsx
+++ b/src/components/Register/atoms/PersonalInfoStep.tsx
@@ -1,25 +1,15 @@
 import { useState, useEffect } from 'react'
 
-import { useRecoilValue } from 'recoil'
-
 import RadioSelector from './RadioSelector'
 import TextareaField from './TextareaField'
 
-import useToast from '../../../hooks/useToast'
-import { ticketListAtom } from '../../../state/ticketListAtom'
 import { FormStepProps } from '../../../types/register.type'
 import BoxButton from '../../common/BoxButton'
-import Checkbox from '../../common/Checkbox'
 import InputField from '../../common/InputField'
 import Spacing from '../../common/Spacing'
-import ToastMessage from '../../common/ToastMessage'
 
 const PersonalInfoStep = ({ nickName, mbti, introduce, contact, updateFields }: FormStepProps) => {
-  const ticketList = useRecoilValue(ticketListAtom)
-
-  const [isChecked, setIsChecked] = useState(false)
-  const { stateToast, showStateToast } = useToast()
-  const canRegister = nickName && mbti.length === 4 && introduce && contact && isChecked
+  const canRegister = nickName && mbti.length === 4 && introduce && contact
 
   const mbtiOptions = [
     ['E', 'I'],
@@ -28,14 +18,6 @@ const PersonalInfoStep = ({ nickName, mbti, introduce, contact, updateFields }: 
     ['P', 'J'],
   ]
   const [mbtiValueArray, setMbtiValueArray] = useState<{ [key: string]: string }>({})
-
-  function checkTicket(isChecked: boolean) {
-    if (ticketList.length > 0) {
-      setIsChecked(isChecked)
-    } else {
-      showStateToast('이용권이 필요한 기능입니다. 이용권 구매 후 사용해주세요!')
-    }
-  }
 
   useEffect(() => {
     updateFields({ mbti: Object.values(mbtiValueArray).join('') })
@@ -114,30 +96,17 @@ const PersonalInfoStep = ({ nickName, mbti, introduce, contact, updateFields }: 
           </div>
         </div>
         <Spacing direction="vertical" size={8} />
-        <div>
-          <Checkbox
-            checkCase="등록"
-            isChecked={isChecked}
-            onImgClick={() => {
-              checkTicket(!isChecked)
-            }}
-            onLabelClick={(e: React.ChangeEvent<HTMLInputElement>) => {
-              checkTicket(e.target.checked)
-            }}
-          />
-          <BoxButton isDisabled={canRegister ? 'abled' : 'disabled'} isLine="filled" size="large">
-            <button
-              type="submit"
-              className="h-full w-full disabled:cursor-not-allowed"
-              disabled={!canRegister}
-            >
-              등록하기
-            </button>
-          </BoxButton>
-        </div>
+        <BoxButton isDisabled={canRegister ? 'abled' : 'disabled'} isLine="filled" size="large">
+          <button
+            type="submit"
+            className="h-full w-full disabled:cursor-not-allowed"
+            disabled={!canRegister}
+          >
+            등록하기
+          </button>
+        </BoxButton>
       </div>
       <Spacing direction="vertical" size={44}></Spacing>
-      {stateToast && <ToastMessage>{stateToast}</ToastMessage>}
     </div>
   )
 }

--- a/src/components/Register/index.tsx
+++ b/src/components/Register/index.tsx
@@ -2,7 +2,6 @@ import { FormEvent, useState, useEffect } from 'react'
 
 import { AxiosError } from 'axios'
 import { useLocation, useNavigate } from 'react-router-dom'
-import { useRecoilState } from 'recoil'
 
 import AnimalStep from './atoms/AnimalStep'
 import GenderStep from './atoms/GenderStep'
@@ -13,25 +12,17 @@ import useMultistepForm from '../../hooks/useMultistepForm'
 import useRecoilToast from '../../hooks/useRecoilToast'
 import useToast from '../../hooks/useToast'
 import { registerToastAtom } from '../../state/registerToastAtom'
-import { ticketListAtom } from '../../state/ticketListAtom'
 import { FormData } from '../../types/register.type'
 import { RegisterRequest } from '../../types/registerApi.type'
 import Spacing from '../common/Spacing'
 import ToastMessage from '../common/ToastMessage'
 
 const Register = () => {
-  const [ticketList, setTicketList] = useRecoilState(ticketListAtom)
-
   const { stateToast, showStateToast } = useToast()
   const { setRecoilStateToast } = useRecoilToast(registerToastAtom)
 
   const navigate = useNavigate()
   const location = useLocation()
-
-  // 보리가 여기서 정보 빼서 사용하시면 됩니다 :)
-  useEffect(() => {
-    console.log(location.state)
-  }, [location.state])
 
   const [formData, setFormData] = useState<FormData>({
     gender: '',
@@ -40,6 +31,7 @@ const Register = () => {
     mbti: '',
     introduce: '',
     contact: '',
+    oauthName: '',
   })
 
   const { currentStepIndex, currentStep, next } = useMultistepForm([
@@ -77,15 +69,14 @@ const Register = () => {
 
   async function onSubmit(e: FormEvent) {
     e.preventDefault()
-    const profile: RegisterRequest = { ...formData, code: ticketList[0] }
+    const profile: RegisterRequest = { ...formData }
     const gender = formData.gender
 
     if ('gender' in profile) delete profile.gender
 
     try {
-      await registerProfile({ gender, profile })
-      const currentTicketList = ticketList.slice(1)
-      setTicketList(currentTicketList)
+      const response = await registerProfile({ gender, profile })
+      // response.ticket으로 ticketcount 설정
       setRecoilStateToast({
         isShow: true,
         toastMessage:
@@ -124,6 +115,16 @@ const Register = () => {
 
     return () => {
       window.removeEventListener('popstate', handlePopState)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (location.state === null) {
+      navigate('/')
+    } else {
+      setFormData((prev) => {
+        return { ...prev, oauthName: location.state.code }
+      })
     }
   }, [])
 

--- a/src/types/register.type.ts
+++ b/src/types/register.type.ts
@@ -5,6 +5,7 @@ export interface FormData {
   mbti: string
   introduce: string
   contact: string
+  oauthName: string
 }
 
 export interface FormStepProps extends FormData {

--- a/src/types/registerApi.type.ts
+++ b/src/types/registerApi.type.ts
@@ -1,8 +1,6 @@
 import { FormData } from './register.type'
 
-export interface RegisterRequest extends Omit<FormData, 'gender'> {
-  code: string
-}
+export interface RegisterRequest extends Omit<FormData, 'gender'> {}
 
 export interface RegisterResponse extends FormData {
   code: string


### PR DESCRIPTION
## 🔍 관련 자료
* 이슈 넘버: #124

## 📝 변경 내용
- `/register`는 최초 로그인 시에만 접근하는 페이지라 이용권 관련 코드를 삭제했습니다
- 따라서 등록 버튼 위에 있던 이용권 차감 안내 체크박스도 지웠습니다

## 📸 결과
#### 테스트 할 때 주의할 점
1. 제가 서버 base url을 잠시 배포 주소 말고 버킷 주소로 바꿔서 실행(녹화)했습니다! 안되는 게 맞아욥

2. 원래 홈으로 돌아왔을 때 전역 토스트가 떠야하는데, 테스트 녹화때 제가 잠시 토스트 코드를 빼고 실행했어요 ㅠㅠ 근데 지금 회원탈퇴가 없어서 재녹화를 못하고 있습니다

| 최초 로그인과 등록 | 서버에 등록된 데이터 |
|---|---|
|![Animation](https://github.com/yourssu/autumn-ssu-dating/assets/87255462/064b73ec-d76a-4fe5-944f-81427be5076c)|![image](https://github.com/yourssu/autumn-ssu-dating/assets/87255462/de392746-992a-4d8d-aa25-1263c18e2a0b)|

그리고 뒤늦게 살짝 끼워넣은 안내 텍스트
![image](https://github.com/yourssu/autumn-ssu-dating/assets/87255462/60b3ec08-a343-4ca3-a4c9-bfa1a3470a49)
