### PR TITLE
Fix: Redirect 컴포넌트 return문 복구

### DIFF
--- a/src/components/Redirect/index.tsx
+++ b/src/components/Redirect/index.tsx
@@ -11,6 +11,8 @@ const Redirect = () => {
       navigate('/register', { state: { code } })
     }
   }, [code])
+
+  return <></>
 }
 
 export default Redirect


### PR DESCRIPTION
## 🔍 관련 자료
* PR 넘버: #125
![image](https://github.com/yourssu/autumn-ssu-dating/assets/87255462/fb4d24bb-df98-4976-aa98-df64e005296f)

## 📝 변경 내용
`Redirect`는 렌더링 요소 없어서 return 지워도 되는 줄 알았는데 Router에서 void 타입을 element에 넣지 말라고 함

## 📸 결과
눈으로 보이는 변경사항 없음~!!~!~ 바로 머지할게요ㅕ