### PR TITLE
Feat/#123 카카오 로그인 토큰 관리 구현

### DIFF
--- a/src/components/Redirect/index.tsx
+++ b/src/components/Redirect/index.tsx
@@ -2,8 +2,12 @@ import { useEffect } from 'react'
 
 import { useNavigate } from 'react-router-dom'
 
+import { setToken } from '../../utils/tokenUtils'
+
 const Redirect = () => {
   const code = new URL(document.location.toString()).searchParams.get('oauthName')
+  const accessToken = new URL(document.location.toString()).searchParams.get('accessToken')
+  const refreshToken = new URL(document.location.toString()).searchParams.get('refreshToken')
   const navigate = useNavigate()
 
   useEffect(() => {
@@ -11,6 +15,10 @@ const Redirect = () => {
       navigate('/register', { state: { code } })
     }
   }, [code])
+
+  useEffect(() => {
+    if (accessToken && refreshToken) setToken(accessToken, refreshToken)
+  }, [accessToken, refreshToken])
 
   return <></>
 }

--- a/src/utils/tokenUtils.ts
+++ b/src/utils/tokenUtils.ts
@@ -1,0 +1,5 @@
+export const setToken = (accessToken: string, refreshToken: string) => {
+  localStorage.clear()
+  localStorage.setItem('accessToken', accessToken)
+  localStorage.setItem('refreshToken', refreshToken)
+}


### PR DESCRIPTION
## 🔍 관련 자료
* 이슈 넘버: #123 

## 📝 변경 내용
- `/utils/tokenUtils/setToken` 함수 생성하여서 토큰 저장하는 메소드 생성했습니다! (보리가 생각하던게 이게 맞겠죠?)
- 리다이렉트된 url에서 accessToken과 refreshToken을 추출해서 localStorage에 각각 저장했습니다.

## 📸 결과
눈에 보이는 변화 없습니다 👀
