### PR TITLE
Fix: signedAtom을 사용한 로그인 여부 확인 (Topbar, Layout, Home)

### DIFF
--- a/src/components/Home/index.tsx
+++ b/src/components/Home/index.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react'
 
 import { AxiosError } from 'axios'
 import { useNavigate } from 'react-router-dom'
-import { useRecoilState } from 'recoil'
+import { useRecoilValue, useRecoilState } from 'recoil'
 
 import AnimalSlide from './atoms/AnimalSlide'
 import Policy from './atoms/Policy'
@@ -13,6 +13,7 @@ import { LOGIN_LINK } from '../../constant'
 import useRecoilToast from '../../hooks/useRecoilToast'
 import useToast from '../../hooks/useToast'
 import { registerToastAtom } from '../../state/registerToastAtom'
+import { signedAtom } from '../../state/signedAtom'
 import { ticketAtom } from '../../state/ticketAtom'
 import BoxButton from '../common/BoxButton'
 import InputField from '../common/InputField'
@@ -20,10 +21,10 @@ import Spacing from '../common/Spacing'
 import ToastMessage from '../common/ToastMessage'
 
 const Home = () => {
-  const isLogged = false // 로그인 기능 추가 후 로그인 여부로 수정 예정
+  const signed = useRecoilValue(signedAtom)
   return (
     <div className="flex h-full select-none flex-col items-center justify-center">
-      {isLogged ? <AfterLogin /> : <BeforeLogin />}
+      {signed ? <AfterLogin /> : <BeforeLogin />}
     </div>
   )
 }

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -1,6 +1,8 @@
 import { Outlet, useLocation } from 'react-router-dom'
+import { useRecoilValue } from 'recoil'
 
 import { LINK_TITLE } from '../../constant'
+import { signedAtom } from '../../state/signedAtom'
 import Spacing from '../common/Spacing'
 import TopBar from '../common/TopBar'
 
@@ -9,10 +11,10 @@ const Layout = () => {
   const { title, backNav } = LINK_TITLE[pathname + search]
 
   const isHome = pathname === '/'
-  const isLogged = false // 로그인 기능 추가 후 로그인 여부로 수정 예정
+  const signed = useRecoilValue(signedAtom)
 
   const bgUrl = isHome
-    ? !isLogged
+    ? !signed
       ? `bg-[url('/src/assets/bg_login_before.png')]`
       : `bg-[url('/src/assets/bg_login_after.png')]`
     : `bg-[url('/src/assets/bg_other.png')]`

--- a/src/components/common/TopBar.tsx
+++ b/src/components/common/TopBar.tsx
@@ -5,6 +5,7 @@ import Spacing from './Spacing'
 
 import leftIcon from '../../assets/leftIcon.svg'
 import ticket from '../../assets/ticket.svg'
+import { signedAtom } from '../../state/signedAtom'
 import { ticketAtom } from '../../state/ticketAtom'
 
 interface TopBarProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -36,11 +37,11 @@ const TopBar = ({ backNav, title, ...props }: TopBarProps) => {
 }
 
 const RightIcon = () => {
-  const isLogged = false // 로그인 기능 추가 후 로그인 여부로 수정 예정
+  const signed = useRecoilValue(signedAtom)
 
   return (
     <div className="flex flex-row items-center">
-      {isLogged ? <TicketCount /> : <span className="w-[60px] text-body2 text-pink">로그인</span>}
+      {signed ? <TicketCount /> : <span className="w-[60px] text-body2 text-pink">로그인</span>}
     </div>
   )
 }


### PR DESCRIPTION
## 🔍 관련 자료
* 이슈 넘버: 
#109
#112
#117

## 📝 변경 내용
- `signedAtom` 값으로 로그인 여부를 판단하게 수정했습니다

## 죄성합니다
원래 규칙대로면? 3개 이슈에 할당된 브랜치 각각에 가서 고치는 게 맞지만??!!
제가 지금 마음이 급하고..... 똑같은 pr 올릴 자신이 ❌ 여서 냅다. 한 곳에서 해버렸습니다

## 📸 결과
![Animation](https://github.com/yourssu/autumn-ssu-dating/assets/87255462/fa379e37-b9f5-4aec-a535-8cf33fddb5d2)
