### PR TITLE
Fix/#146 토큰 만료 시 로그인 풀리도록 interceptor 로직 수정

### DIFF
--- a/src/apis/client.ts
+++ b/src/apis/client.ts
@@ -3,7 +3,7 @@ import { jwtDecode } from 'jwt-decode'
 
 import { refresh } from './refresh'
 
-import { clearToken, getAccessToken, getRefreshToken, setToken } from '../utils/tokenUtils'
+import { getAccessToken, getRefreshToken, setToken } from '../utils/tokenUtils'
 
 interface AxiosCustomRequestConfig extends AxiosRequestConfig {
   retryCount: number
@@ -52,11 +52,11 @@ client.interceptors.response.use(
 
           return client(originRequest)
         } else {
-          clearToken()
+          localStorage.clear()
           window.location.assign('/')
         }
       } catch {
-        clearToken()
+        localStorage.clear()
         window.location.assign('/')
       }
     }


### PR DESCRIPTION
## 🔍 관련 자료
* 이슈 넘버: #146 

## 📝 변경 내용
||토큰 만료 시 recoil-persist가 localStorage에|
|---|---|
|기존|남아있다|
|현재|남아있지 않다|

## 📸 결과
로그인 한 상태에서 ➡ 스웨거에서 로그아웃 ➡ 회원 전용 url로 접근 시 로그인이 풀리는 걸 확인 가능
![giff2](https://github.com/yourssu/autumn-ssu-dating/assets/87255462/3a2a4db9-8ca0-44f6-b830-f424659eb7da)
