### PR TITLE
fix: `getImageSrc` 확장자 수정

### DIFF
--- a/src/utils/animalUtil.ts
+++ b/src/utils/animalUtil.ts
@@ -44,5 +44,5 @@ export const animalServerToClient = (animal: AnimalServerType): AnimalType => {
 }
 
 export const getImageSrc = (animal: Omit<AnimalServerType, 'ALL'>): string => {
-  return `/${animal.toLocaleLowerCase()}Icon.png`
+  return `/${animal.toLocaleLowerCase()}Icon.webp`
 }


### PR DESCRIPTION
## 📝 변경 내용
마이페이지에서 파일명 생성을 위해 사용하는 `getImageSrc()`에 png를 남겨놔서,
webp 파일을 못 불러오는 상황을 수정했습니다

정말 민망하네요 먼저 합치겠습니다!!!