### PR TITLE
🐛 TextareaField classname 수정 (font-body1 -> text-body1)

### DIFF
--- a/src/components/Register/atoms/TextareaField.tsx
+++ b/src/components/Register/atoms/TextareaField.tsx
@@ -4,7 +4,7 @@ interface TextareaFieldProps extends React.TextareaHTMLAttributes<HTMLTextAreaEl
 
 const TextareaField = ({ height = 127, ...props }: TextareaFieldProps) => {
   const defaultStyle =
-    'p-4 bg-white rounded-xl text-pink placeholder-gray font-body1 resize-none focus:outline-none focus:shadow-inputField'
+    'p-4 bg-white rounded-xl text-pink placeholder-gray text-body1 resize-none focus:outline-none focus:shadow-inputField'
   const shadowStyle = !props.value && 'shadow-inputField'
 
   return (


### PR DESCRIPTION
## 📝 변경 내용
- `TextareaField` 클릭 시 여전히 줌인되는 문제가 있어 살펴보니,,
  font-body1으로 스타일 적용하고 있어서 안 먹었던 거였어요 정말 민망하네요
  text-body1으로 수정했습니다

